### PR TITLE
Remove optimization

### DIFF
--- a/Products/ExtendedPathIndex/ExtendedPathIndex.py
+++ b/Products/ExtendedPathIndex/ExtendedPathIndex.py
@@ -228,9 +228,6 @@ class ExtendedPathIndex(PathIndex):
         if navtree and navtree_start > min(pathlength + depth, self._depth):
             # This navtree_start excludes all items that match the depth
             return IISet()
-        if pathlength > self._depth:
-            # Our search is for a path longer than anything in the index
-            return IISet()
 
         if level == 0 and depth in (0, 1):
             # We have easy indexes for absolute paths where

--- a/Products/ExtendedPathIndex/tests/testExtendedPathIndex.py
+++ b/Products/ExtendedPathIndex/tests/testExtendedPathIndex.py
@@ -158,6 +158,7 @@ class TestExtendedPathIndex(unittest.TestCase):
             ('/aa/aa/x', 0, [8]),
             ('/aa/bb', 0, [8, 9]),
             ('/aa/bb/x', 0, [8, 9]),
+            ('/aa/bb/x/y/z', 0, [8, 9]),
             ]
         for path, level, results in tests:
             res = self._index._apply_index(dict(


### PR DESCRIPTION
This optimization seems to short-circuit navtree-searches when the input path is longer than any of the indexed values – `self._depth` in the code.

The behavior is inconsistent, because as long as the input path length is shorter or equal to the longest indexed path, there is no requirement that the entire path is indexed already.
