### PR TITLE
Fix dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Fix dependencies defined in setup.py.
+  [gforcada]
 
 3.3.0 (2018-01-17)
 ------------------

--- a/Products/ExtendedPathIndex/tests/testExtendedPathIndex.py
+++ b/Products/ExtendedPathIndex/tests/testExtendedPathIndex.py
@@ -1,6 +1,3 @@
-import AccessControl  # here to avoid cyclic import
-AccessControl  # pyflakes
-
 import unittest
 
 from BTrees.IIBTree import IISet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.dependencychecker]
+"ZODB3" = ['BTrees']
+"Products.ZCatalog" = ['Products.PluginIndexes']
+"Zope2" = ['App']

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,10 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'AccessControl',
         'Products.ZCatalog',
         'six',
-        'transaction',
         'ZODB3',
         'Zope2 >= 2.13.0a3',
+        'zope.interface',
     ],
     )


### PR DESCRIPTION
@davisagli in 2009 you introduced the ``AccessControl`` import, to avoid a circular import: https://github.com/plone/Products.ExtendedPathIndex/commit/67e376ad2e55ef5601c91a984b6b5deee566a96f

Could we assume that this is no longer the case? :sweat_smile: 

Let's see what Jenkins says.

This is the first package being cleaned up with ``z3c.dependencychecker``, actually it needs a pull request pending to be merged (https://github.com/reinout/z3c.dependencychecker/pull/90) to work as expected.

It is part of PLIP https://github.com/plone/Products.CMFPlone/issues/2448