### PR TITLE
Revert "Support allow multi value results for virtual paths."

### DIFF
--- a/Products/ExtendedPathIndex/ExtendedPathIndex.py
+++ b/Products/ExtendedPathIndex/ExtendedPathIndex.py
@@ -53,7 +53,6 @@ class ExtendedPathIndex(PathIndex):
     )
 
     indexed_attrs = None
-    multi_valued = False
     query_options = ("query", "level", "operator",
                      "depth", "navtree", "navtree_start")
 
@@ -63,10 +62,8 @@ class ExtendedPathIndex(PathIndex):
 
         if isinstance(extra, dict):
             attrs = extra.get('indexed_attrs', None)
-            self.multi_valued = extra.get('multi_valued', False)
         else:
             attrs = getattr(extra, 'indexed_attrs', None)
-            self.multi_valued = getattr(extra, 'multi_valued', False)
 
         if attrs is None:
             return
@@ -248,7 +245,7 @@ class ExtendedPathIndex(PathIndex):
                 # Optimized absolute path navtree and breadcrumbs cases
                 result = []
                 add = lambda x: x is not None and result.append(x)
-                if depth == 1 and not self.multi_valued:
+                if depth == 1:
                     # Navtree case, all sibling elements along the path
                     convert = multiunion
                     index = self._index_parents
@@ -264,7 +261,7 @@ class ExtendedPathIndex(PathIndex):
 
             if not path.startswith('/'):
                 path = '/' + path
-            if depth == 0 and not self.multi_valued:
+            if depth == 0:
                 # Specific object search
                 res = self._index_items.get(path)
                 return res and IISet([res]) or IISet()


### PR DESCRIPTION
This reverts commit 10093bdc4d3ada6bd45d25a2d48cf6668ce5c802.
This might be the cause of some Jenkins robot failures in 'Test Edit User Schema'. See:
- https://jenkins.plone.org/job/plone-5.1-python-2.7-robot-chrome/432/
- https://jenkins.plone.org/job/plone-5.0-python-2.7-robot-chrome/268/
- https://jenkins.plone.org/job/plone-5.2-python-3.6-robot-chrome/282/
I don't see a link between those robot tests and PR #8 of `Products.ExtendedPathIndex`, but the failures started after this change, so let's see what Jenkins says.

cc @jensens 